### PR TITLE
Add support for custom cache implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function box (name, key) {
   if (!_cache) _cache = require('./lib/cache')()
 
   if (key && _cache.get(name + '-' + key)) {
-    return _cache.get[name + '-' + key]
+    return _cache.get(name + '-' + key)
   } else if (key) {
     var value = components[name]()
     _cache.set(name + '-' + key, value)

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ box.use = function (newcomponents) {
 }
 
 box.cache = function(cache) {
-  assert.ok(typeof cache.get, 'function', 'component-box.cache: cache should have get property of type function')
-  assert.ok(typeof cache.set, 'function', 'component-box.cache: cache should have set property of type function')
-  assert.ok(typeof cache.remove, 'function', 'component-box.cache: cache should have remove property of type function')
+  assert.equal(typeof cache.get, 'function', 'component-box.cache: cache should have get property of type function')
+  assert.equal(typeof cache.set, 'function', 'component-box.cache: cache should have set property of type function')
+  assert.equal(typeof cache.remove, 'function', 'component-box.cache: cache should have remove property of type function')
   _cache = cache
 }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,18 @@
+module.exports = Cache
+
+function Cache() {
+  if (!(this instanceof Cache)) return new Cache()
+  this._cache = {}
+}
+
+Cache.prototype.get = function (key) {
+  return this._cache[key]
+}
+
+Cache.prototype.set = function (key, value) {
+  this._cache[key] = value
+}
+
+Cache.prototype.remove = function (key) {
+  delete this._cache[key]
+}

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,24 @@ c.delete('mycomponent')
 c('mycomponent')
 ```
 
+### `c.cache(cache)`
+
+Use a custom cache implementation. Expects an object with `.get`, `.set`, and `.remove` methods.
+
+```js
+var c = require('component-box')
+
+c.cache(require('lru')(2)) // only cache 2 instances, using lru eviction
+
+c.use({
+  post: postComponent
+})
+
+c('post', 'slug1').render()
+c('post', 'slug2').render()
+c('post', 'slug3').render() // evict 'post-slug1' and return new 'post-slug3' instance
+```
+
 ## Alternative Pattern
 
 You could also choose to only return the `.render` method from nanocomponent, allowing for a slightly more concise syntax:

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ test('c(\'component\')', function (t) {
 
   var box = c._inspect()
 
-  t.ok('component' in box.cache, '`component` created and cached as `component`')
+  t.ok(box._cache.get('component'), '`component` created and cached as `component`')
   t.end()
 })
 
@@ -26,7 +26,7 @@ test('c(\'component\', \'custom\')', function (t) {
 
   var box = c._inspect()
 
-  t.ok('component-custom' in box.cache, '`component` created and cached as `custom`')
+  t.ok(box._cache.get('component-custom'), '`component` created and cached as `custom`')
   t.end()
 })
 
@@ -35,7 +35,7 @@ test('c.delete(\'component\')', function (t) {
 
   var box = c._inspect()
 
-  t.notOk('component' in box.cache, '`component` uncached')
+  t.notOk(box._cache.get('component'), '`component` uncached')
   t.end()
 })
 
@@ -44,6 +44,6 @@ test('c(\'component\', false)', function (t) {
 
   var box = c._inspect()
 
-  t.notOk('component' in box.cache, '`component` created and not cached')
+  t.notOk(box._cache.get('component'), '`component` created and not cached')
   t.end()
 })


### PR DESCRIPTION
I love the simplicity of `component-box`, but wanted to set a max number of instances that could be cached.

This PR adds a new method to the API: `c.cache()`, which accepts any object with `get`, `set`, and `remove` properties to function as the custom cache implementation.

This makes the following possible:
```js
var c = require('component-box')

c.cache(require('lru')(2)) // only cache 2 instances, using lru eviction

c.use({
  post: postComponent
})

c('post', 'slug1').render()
c('post', 'slug2').render()
c('post', 'slug3').render() // evict 'post-slug1' and return new 'post-slug3' instance

```

WDYT? If you like the idea, I'm happy to update the readme, too..