### PR TITLE
feat(): allow constructor args to be passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,19 +6,28 @@ var _cache = null
 
 module.exports = box
 
-function box (name, key) {
+function box(name, opts) {
   assert.ok(typeof name === 'string' || typeof name === 'number', 'component-box: name should be type string or number')
   assert.ok(components[name], 'component-box: no component handler found for [' + name + ']')
+
+  var key
+  var constructorArgs
+  var shouldCache
+  if (opts) {
+    key = opts.key
+    constructorArgs = opts.constructorArgs
+    shouldCache = opts.cache
+  }
 
   if (!_cache) _cache = require('./lib/cache')()
 
   if (key && _cache.get(name + '-' + key)) {
     return _cache.get(name + '-' + key)
   } else if (key) {
-    var value = components[name]()
+    var value = components[name].apply(null, constructorArgs)
     _cache.set(name + '-' + key, value)
     return value
-  } else if (key === false) {
+  } else if (shouldCache === false) {
     return components[name]()
   } else if (name && _cache.get(name)) {
     return _cache.get(name)
@@ -38,7 +47,7 @@ box.use = function (newcomponents) {
   components = x(components, newcomponents)
 }
 
-box.cache = function(cache) {
+box.cache = function (cache) {
   assert.equal(typeof cache.get, 'function', 'component-box.cache: cache should have get property of type function')
   assert.equal(typeof cache.set, 'function', 'component-box.cache: cache should have set property of type function')
   assert.equal(typeof cache.remove, 'function', 'component-box.cache: cache should have remove property of type function')

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -38,8 +38,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -54,11 +54,11 @@
       "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -67,9 +67,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "for-each": {
@@ -78,7 +78,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "foreach": {
@@ -105,12 +105,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "has": {
@@ -119,7 +119,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "inflight": {
@@ -128,8 +128,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -162,7 +162,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -177,7 +177,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -209,7 +209,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -230,7 +230,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resumer": {
@@ -239,7 +239,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "string.prototype.trim": {
@@ -248,9 +248,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "tape": {
@@ -259,19 +259,19 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       }
     },
     "through": {

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ test('c(\'component\')', function (t) {
 })
 
 test('c(\'component\', \'custom\')', function (t) {
-  c('component', 'custom')
+  c('component', { key: 'custom' })
 
   var box = c._inspect()
 
@@ -40,7 +40,7 @@ test('c.delete(\'component\')', function (t) {
 })
 
 test('c(\'component\', false)', function (t) {
-  c('component', false)
+  c('component', { cache: false })
 
   var box = c._inspect()
 


### PR DESCRIPTION
Allows for constructor args to be passed in. This would be a breaking API change though. We could prob skirt around a major bump by taking advantage of the positions of args instead of passing in an object ie

```js
c('dummy', { key: 'key', constructorArgs: ['oh hai mark']})
```
becomes something like 
```js
c('dummy', null,  ['oh hai mark'])
```

This is a great little tool, thanks for sharing :D 